### PR TITLE
LPS 167246 final

### DIFF
--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskMessagingConfigurator.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskMessagingConfigurator.java
@@ -19,12 +19,14 @@ import com.liferay.portal.kernel.messaging.DestinationConfiguration;
 import com.liferay.portal.kernel.messaging.DestinationFactory;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.MessageBus;
+import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.util.MapUtil;
 
 import java.util.ArrayList;
+import java.util.Dictionary;
 import java.util.List;
 import java.util.Map;
 
@@ -52,23 +54,19 @@ public class BackgroundTaskMessagingConfigurator {
 			ConfigurableUtil.createConfigurable(
 				BackgroundTaskManagerConfiguration.class, properties);
 
-		Destination backgroundTaskDestination = _registerDestination(
+		_registerMessaging(
 			bundleContext, DestinationConfiguration.DESTINATION_TYPE_PARALLEL,
 			DestinationNames.BACKGROUND_TASK,
 			backgroundTaskManagerConfiguration.workersCoreSize(),
-			backgroundTaskManagerConfiguration.workersMaxSize());
-
-		backgroundTaskDestination.register(
+			backgroundTaskManagerConfiguration.workersMaxSize(),
 			new BackgroundTaskMessageListener(
 				_backgroundTaskExecutorRegistry, _backgroundTaskLocalService,
 				_backgroundTaskStatusRegistry,
 				_backgroundTaskThreadLocalManager, _lockManager, _messageBus));
 
-		Destination backgroundTaskStatusDestination = _registerDestination(
+		_registerMessaging(
 			bundleContext, DestinationConfiguration.DESTINATION_TYPE_SERIAL,
-			DestinationNames.BACKGROUND_TASK_STATUS, 1, 1);
-
-		backgroundTaskStatusDestination.register(
+			DestinationNames.BACKGROUND_TASK_STATUS, 1, 1,
 			new BackgroundTaskStatusMessageListener(
 				_backgroundTaskLocalService, _backgroundTaskStatusRegistry,
 				_lockManager, _roleLocalService, _userLocalService,
@@ -77,16 +75,17 @@ public class BackgroundTaskMessagingConfigurator {
 
 	@Deactivate
 	protected void deactivate() {
-		for (ServiceRegistration<Destination> serviceRegistration :
+		for (ServiceRegistration<?> serviceRegistration :
 				_serviceRegistrations) {
 
 			serviceRegistration.unregister();
 		}
 	}
 
-	private Destination _registerDestination(
+	private void _registerMessaging(
 		BundleContext bundleContext, String destinationType,
-		String destinationName, int workersCoreSize, int workersMaxSize) {
+		String destinationName, int workersCoreSize, int workersMaxSize,
+		MessageListener messageListener) {
 
 		DestinationConfiguration destinationConfiguration =
 			new DestinationConfiguration(destinationType, destinationName);
@@ -97,13 +96,16 @@ public class BackgroundTaskMessagingConfigurator {
 		Destination destination = _destinationFactory.createDestination(
 			destinationConfiguration);
 
+		Dictionary<String, String> dictionary = MapUtil.singletonDictionary(
+			"destination.name", destination.getName());
+
 		_serviceRegistrations.add(
 			bundleContext.registerService(
-				Destination.class, destination,
-				MapUtil.singletonDictionary(
-					"destination.name", destination.getName())));
+				Destination.class, destination, dictionary));
 
-		return destination;
+		_serviceRegistrations.add(
+			bundleContext.registerService(
+				MessageListener.class, messageListener, dictionary));
 	}
 
 	@Reference
@@ -130,7 +132,7 @@ public class BackgroundTaskMessagingConfigurator {
 	@Reference
 	private RoleLocalService _roleLocalService;
 
-	private final List<ServiceRegistration<Destination>> _serviceRegistrations =
+	private final List<ServiceRegistration<?>> _serviceRegistrations =
 		new ArrayList<>();
 
 	@Reference

--- a/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
+++ b/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
@@ -316,44 +316,37 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 
 		_bundleContext = componentContext.getBundleContext();
 
-		_registerDestination(
-			_bundleContext, DestinationConfiguration.DESTINATION_TYPE_PARALLEL,
-			DestinationNames.SCHEDULER_DISPATCH);
-
-		Destination scriptingDestination = _registerDestination(
-			_bundleContext, DestinationConfiguration.DESTINATION_TYPE_PARALLEL,
-			DestinationNames.SCHEDULER_SCRIPTING);
+		_registerMessaging(
+			_bundleContext, DestinationNames.SCHEDULER_DISPATCH, null);
 
 		ScriptingMessageListener scriptingMessageListener =
 			new ScriptingMessageListener();
 
-		SchedulerJobConfigurationMessageListener
-			schedulerJobConfigurationMessageListener =
-				new SchedulerJobConfigurationMessageListener(
-					new SchedulerJobConfiguration() {
+		_registerMessaging(
+			_bundleContext, DestinationNames.SCHEDULER_SCRIPTING,
+			new SchedulerJobConfigurationMessageListener(
+				new SchedulerJobConfiguration() {
 
-						@Override
-						public UnsafeConsumer<Message, Exception>
-							getJobExecutorUnsafeConsumer() {
+					@Override
+					public UnsafeConsumer<Message, Exception>
+						getJobExecutorUnsafeConsumer() {
 
-							return scriptingMessageListener::receive;
-						}
+						return scriptingMessageListener::receive;
+					}
 
-						@Override
-						public UnsafeRunnable<Exception>
-							getJobExecutorUnsafeRunnable() {
+					@Override
+					public UnsafeRunnable<Exception>
+						getJobExecutorUnsafeRunnable() {
 
-							return null;
-						}
+						return null;
+					}
 
-						@Override
-						public TriggerConfiguration getTriggerConfiguration() {
-							return null;
-						}
+					@Override
+					public TriggerConfiguration getTriggerConfiguration() {
+						return null;
+					}
 
-					});
-
-		scriptingDestination.register(schedulerJobConfigurationMessageListener);
+				}));
 
 		DependencyManagerSyncUtil.registerSyncCallable(
 			() -> {
@@ -385,8 +378,8 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 			}
 		}
 
-		for (ServiceRegistration<Destination> serviceRegistration :
-				_destinationServiceRegistrations) {
+		for (ServiceRegistration<?> serviceRegistration :
+				_serviceRegistrations) {
 
 			serviceRegistration.unregister();
 		}
@@ -401,12 +394,14 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 				SchedulerEngineHelperConfiguration.class, properties);
 	}
 
-	private Destination _registerDestination(
-		BundleContext bundleContext, String destinationType,
-		String destinationName) {
+	private void _registerMessaging(
+		BundleContext bundleContext, String destinationName,
+		MessageListener messageListener) {
 
 		DestinationConfiguration destinationConfiguration =
-			new DestinationConfiguration(destinationType, destinationName);
+			new DestinationConfiguration(
+				DestinationConfiguration.DESTINATION_TYPE_PARALLEL,
+				destinationName);
 
 		Destination destination = _destinationFactory.createDestination(
 			destinationConfiguration);
@@ -416,13 +411,17 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 				"destination.name", destination.getName()
 			).build();
 
-		ServiceRegistration<Destination> serviceRegistration =
+		_serviceRegistrations.add(
 			bundleContext.registerService(
-				Destination.class, destination, dictionary);
+				Destination.class, destination, dictionary));
 
-		_destinationServiceRegistrations.add(serviceRegistration);
+		if (messageListener == null) {
+			return;
+		}
 
-		return destination;
+		_serviceRegistrations.add(
+			bundleContext.registerService(
+				MessageListener.class, messageListener, dictionary));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
@@ -436,9 +435,6 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 
 	@Reference
 	private DestinationFactory _destinationFactory;
-
-	private final List<ServiceRegistration<Destination>>
-		_destinationServiceRegistrations = new ArrayList<>();
 
 	@Reference
 	private JSONFactory _jsonFactory;
@@ -459,6 +455,8 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 		_schedulerEngineHelperConfiguration;
 	private ServiceTracker<SchedulerJobConfiguration, SchedulerJobConfiguration>
 		_schedulerJobConfigurationServiceTracker;
+	private final List<ServiceRegistration<?>> _serviceRegistrations =
+		new ArrayList<>();
 
 	@Reference
 	private TriggerFactory _triggerFactory;

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/portlet/action/EditMVCActionCommand.java
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/java/com/liferay/portal/search/admin/web/internal/portlet/action/EditMVCActionCommand.java
@@ -11,9 +11,7 @@ import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstant
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.messaging.Destination;
 import com.liferay.portal.kernel.messaging.DestinationNames;
-import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
@@ -25,6 +23,7 @@ import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
@@ -46,6 +45,9 @@ import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.PortletSession;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -112,6 +114,11 @@ public class EditMVCActionCommand extends BaseMVCActionCommand {
 		sendRedirect(actionRequest, actionResponse, redirect);
 	}
 
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
+	}
+
 	private void _reindex(ActionRequest actionRequest) throws Exception {
 		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -172,10 +179,12 @@ public class EditMVCActionCommand extends BaseMVCActionCommand {
 			countDownLatch.countDown();
 		};
 
-		Destination destination = _messageBus.getDestination(
-			DestinationNames.BACKGROUND_TASK_STATUS);
-
-		destination.register(messageListener);
+		ServiceRegistration<MessageListener> serviceRegistration =
+			_bundleContext.registerService(
+				MessageListener.class, messageListener,
+				MapUtil.singletonDictionary(
+					"destination.name",
+					DestinationNames.BACKGROUND_TASK_STATUS));
 
 		try {
 			_indexWriterHelper.reindex(
@@ -187,7 +196,7 @@ public class EditMVCActionCommand extends BaseMVCActionCommand {
 				TimeUnit.MILLISECONDS);
 		}
 		finally {
-			destination.unregister(messageListener);
+			serviceRegistration.unregister();
 		}
 	}
 
@@ -245,14 +254,13 @@ public class EditMVCActionCommand extends BaseMVCActionCommand {
 	private static final Log _log = LogFactoryUtil.getLog(
 		EditMVCActionCommand.class);
 
+	private BundleContext _bundleContext;
+
 	@Reference
 	private IndexReindexerRegistry _indexReindexerRegistry;
 
 	@Reference
 	private IndexWriterHelper _indexWriterHelper;
-
-	@Reference
-	private MessageBus _messageBus;
 
 	@Reference
 	private PortalInstancesLocalService _portalInstancesLocalService;

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/messaging/test/BaseDBPartitionMessageBusInterceptorTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/messaging/test/BaseDBPartitionMessageBusInterceptorTestCase.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.messaging.DestinationFactory;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.messaging.MessageBusInterceptor;
+import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.scheduler.SchedulerEngine;
@@ -32,6 +33,7 @@ import com.liferay.portal.util.PropsUtil;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Dictionary;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -58,7 +60,13 @@ public abstract class BaseDBPartitionMessageBusInterceptorTestCase
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
-		_serviceRegistration.unregister();
+		for (ServiceRegistration<?> serviceRegistration :
+				_serviceRegistrations) {
+
+			serviceRegistration.unregister();
+		}
+
+		_serviceRegistrations.clear();
 
 		PropsUtil.set(
 			"database.partition.enabled", _originalDatabasePartitionEnabled);
@@ -261,16 +269,21 @@ public abstract class BaseDBPartitionMessageBusInterceptorTestCase
 		Destination destination = _destinationFactory.createDestination(
 			new DestinationConfiguration(destinationType, _DESTINATION_NAME));
 
-		destination.register(_testDBPartitionMessageListener);
-
 		Bundle bundle = FrameworkUtil.getBundle(
 			BaseDBPartitionMessageBusInterceptorTestCase.class);
 
 		BundleContext bundleContext = bundle.getBundleContext();
 
-		_serviceRegistration = bundleContext.registerService(
-			Destination.class, destination,
-			MapUtil.singletonDictionary("destination.name", _DESTINATION_NAME));
+		Dictionary<String, Object> dictionary = MapUtil.singletonDictionary(
+			"destination.name", destination.getName());
+
+		_serviceRegistrations.add(
+			bundleContext.registerService(
+				Destination.class, destination, dictionary));
+		_serviceRegistrations.add(
+			bundleContext.registerService(
+				MessageListener.class, _testDBPartitionMessageListener,
+				dictionary));
 	}
 
 	private static final String _DESTINATION_NAME = "liferay/test_dbpartition";
@@ -296,7 +309,7 @@ public abstract class BaseDBPartitionMessageBusInterceptorTestCase
 
 	private static String _originalDatabasePartitionEnabled;
 	private static String _originalName;
-	private static ServiceRegistration<Destination> _serviceRegistration;
+	private static List<ServiceRegistration<?>> _serviceRegistrations;
 	private static TestDBPartitionMessageListener
 		_testDBPartitionMessageListener;
 

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/BaseAsyncDestination.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/BaseAsyncDestination.java
@@ -22,7 +22,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.NamedThreadFactory;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 
-import java.util.Set;
+import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -134,6 +134,9 @@ public abstract class BaseAsyncDestination extends BaseDestination {
 
 	@Override
 	public void send(Message message) {
+		List<MessageListener> messageListeners =
+			messageListenerRegistry.getMessageListeners(name);
+
 		if (messageListeners.isEmpty()) {
 			if (_log.isDebugEnabled()) {
 				_log.debug("No message listeners for destination " + getName());
@@ -242,7 +245,7 @@ public abstract class BaseAsyncDestination extends BaseDestination {
 	}
 
 	protected abstract void dispatch(
-		Set<MessageListener> messageListeners, Message message);
+		List<MessageListener> messageListeners, Message message);
 
 	protected void execute(Runnable runnable) {
 		_noticeableThreadPoolExecutor.execute(runnable);

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultDestinationFactory.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultDestinationFactory.java
@@ -9,6 +9,7 @@ import com.liferay.petra.executor.PortalExecutorManager;
 import com.liferay.portal.kernel.messaging.Destination;
 import com.liferay.portal.kernel.messaging.DestinationConfiguration;
 import com.liferay.portal.kernel.messaging.DestinationFactory;
+import com.liferay.portal.kernel.messaging.MessageListenerRegistry;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.service.UserLocalService;
 
@@ -57,15 +58,15 @@ public class DefaultDestinationFactory implements DestinationFactory {
 			DestinationConfiguration.DESTINATION_TYPE_PARALLEL,
 			new ParallelDestinationPrototype(
 				_portalExecutorManager, _permissionCheckerFactory,
-				_userLocalService));
+				_userLocalService, _messageListenerRegistry));
 		_destinationPrototypes.put(
 			DestinationConfiguration.DESTINATION_TYPE_SERIAL,
 			new SerialDestinationPrototype(
 				_portalExecutorManager, _permissionCheckerFactory,
-				_userLocalService));
+				_userLocalService, _messageListenerRegistry));
 		_destinationPrototypes.put(
 			DestinationConfiguration.DESTINATION_TYPE_SYNCHRONOUS,
-			new SynchronousDestinationPrototype());
+			new SynchronousDestinationPrototype(_messageListenerRegistry));
 	}
 
 	@Deactivate
@@ -75,6 +76,9 @@ public class DefaultDestinationFactory implements DestinationFactory {
 
 	private final ConcurrentMap<String, DestinationPrototype>
 		_destinationPrototypes = new ConcurrentHashMap<>();
+
+	@Reference
+	private MessageListenerRegistry _messageListenerRegistry;
 
 	@Reference
 	private PermissionCheckerFactory _permissionCheckerFactory;

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java
@@ -7,36 +7,27 @@ package com.liferay.portal.messaging.internal;
 
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.Destination;
-import com.liferay.portal.kernel.messaging.DestinationEventListener;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.messaging.MessageBusEventListener;
 import com.liferay.portal.kernel.messaging.MessageBusInterceptor;
-import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.messaging.internal.configuration.DestinationWorkerConfiguration;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Dictionary;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
-import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedServiceFactory;
@@ -47,8 +38,6 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
-import org.osgi.util.tracker.ServiceTracker;
-import org.osgi.util.tracker.ServiceTrackerCustomizer;
 
 /**
  * @author Michael C. Han
@@ -129,60 +118,6 @@ public class DefaultMessageBus implements MessageBus {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		_messageListenerServiceTracker = new ServiceTracker<>(
-			bundleContext, MessageListener.class,
-			new ServiceTrackerCustomizer
-				<MessageListener, ObjectValuePair<String, MessageListener>>() {
-
-				@Override
-				public ObjectValuePair<String, MessageListener> addingService(
-					ServiceReference<MessageListener> serviceReference) {
-
-					String destinationName =
-						(String)serviceReference.getProperty(
-							"destination.name");
-
-					if (destinationName == null) {
-						return null;
-					}
-
-					MessageListener messageListener = bundleContext.getService(
-						serviceReference);
-
-					_registerMessageListener(destinationName, messageListener);
-
-					return new ObjectValuePair<>(
-						destinationName, messageListener);
-				}
-
-				@Override
-				public void modifiedService(
-					ServiceReference<MessageListener> serviceReference,
-					ObjectValuePair<String, MessageListener> objectValuePair) {
-
-					removedService(serviceReference, objectValuePair);
-
-					ObjectValuePair<String, MessageListener>
-						newObjectValuePair = addingService(serviceReference);
-
-					objectValuePair.setKey(newObjectValuePair.getKey());
-				}
-
-				@Override
-				public void removedService(
-					ServiceReference<MessageListener> serviceReference,
-					ObjectValuePair<String, MessageListener> objectValuePair) {
-
-					_unregisterMessageListener(
-						objectValuePair.getKey(), objectValuePair.getValue());
-
-					bundleContext.ungetService(serviceReference);
-				}
-
-			});
-
-		_messageListenerServiceTracker.open();
-
 		_serviceRegistration = bundleContext.registerService(
 			ManagedServiceFactory.class,
 			new DefaultMessageBusManagedServiceFactory(),
@@ -201,8 +136,6 @@ public class DefaultMessageBus implements MessageBus {
 		_serviceTrackerList.close();
 
 		_serviceRegistration.unregister();
-
-		_messageListenerServiceTracker.close();
 
 		_messageBusEventListeners.clear();
 
@@ -238,34 +171,6 @@ public class DefaultMessageBus implements MessageBus {
 	@Reference(
 		cardinality = ReferenceCardinality.MULTIPLE,
 		policy = ReferencePolicy.DYNAMIC,
-		policyOption = ReferencePolicyOption.GREEDY,
-		target = "(destination.name=*)"
-	)
-	protected synchronized void registerDestinationEventListener(
-		DestinationEventListener destinationEventListener,
-		Map<String, Object> properties) {
-
-		String destinationName = MapUtil.getString(
-			properties, "destination.name");
-
-		Destination destination = _destinations.get(destinationName);
-
-		if (destination == null) {
-			if (_log.isInfoEnabled()) {
-				_log.info(
-					"Unable to unregister destination event listener for " +
-						destinationName);
-			}
-
-			return;
-		}
-
-		destination.addDestinationEventListener(destinationEventListener);
-	}
-
-	@Reference(
-		cardinality = ReferenceCardinality.MULTIPLE,
-		policy = ReferencePolicy.DYNAMIC,
 		policyOption = ReferencePolicyOption.GREEDY
 	)
 	protected void registerMessageBusEventListener(
@@ -280,28 +185,6 @@ public class DefaultMessageBus implements MessageBus {
 		_removeDestination(destination.getName());
 	}
 
-	protected synchronized void unregisterDestinationEventListener(
-		DestinationEventListener destinationEventListener,
-		Map<String, Object> properties) {
-
-		String destinationName = MapUtil.getString(
-			properties, "destination.name");
-
-		Destination destination = _destinations.get(destinationName);
-
-		if (destination == null) {
-			if (_log.isInfoEnabled()) {
-				_log.info(
-					"Unable to unregister destination event listener for " +
-						destinationName);
-			}
-
-			return;
-		}
-
-		destination.removeDestinationEventListener(destinationEventListener);
-	}
-
 	protected void unregisterMessageBusEventListener(
 		MessageBusEventListener messageBusEventListener) {
 
@@ -310,32 +193,6 @@ public class DefaultMessageBus implements MessageBus {
 
 	private void _addDestination(Destination destination) {
 		Destination oldDestination = _destinations.get(destination.getName());
-
-		if (oldDestination != null) {
-			oldDestination.copyDestinationEventListeners(destination);
-			oldDestination.copyMessageListeners(destination);
-		}
-		else {
-			List<MessageListener> messageListeners =
-				_queuedMessageListeners.remove(destination.getName());
-
-			if (ListUtil.isNotEmpty(messageListeners)) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(
-						StringBundler.concat(
-							"Registering ", messageListeners.size(),
-							" queued message listeners for destination ",
-							destination.getName()));
-				}
-
-				Thread currentThread = Thread.currentThread();
-
-				for (MessageListener messageListener : messageListeners) {
-					destination.register(
-						messageListener, currentThread.getContextClassLoader());
-				}
-			}
-		}
 
 		destination.open();
 
@@ -358,39 +215,6 @@ public class DefaultMessageBus implements MessageBus {
 		}
 	}
 
-	private synchronized boolean _registerMessageListener(
-		String destinationName, MessageListener messageListener) {
-
-		Destination destination = _destinations.get(destinationName);
-
-		if (destination != null) {
-			Thread currentThread = Thread.currentThread();
-
-			return destination.register(
-				messageListener, currentThread.getContextClassLoader());
-		}
-
-		List<MessageListener> queuedMessageListeners =
-			_queuedMessageListeners.get(destinationName);
-
-		if (queuedMessageListeners == null) {
-			queuedMessageListeners = new ArrayList<>();
-
-			_queuedMessageListeners.put(
-				destinationName, queuedMessageListeners);
-		}
-
-		queuedMessageListeners.add(messageListener);
-
-		if (_log.isWarnEnabled()) {
-			_log.warn(
-				"Queuing message listener until destination " +
-					destinationName + " is added");
-		}
-
-		return false;
-	}
-
 	private Destination _removeDestination(String destinationName) {
 		Destination destination = _destinations.remove(destinationName);
 
@@ -407,25 +231,6 @@ public class DefaultMessageBus implements MessageBus {
 		}
 
 		return destination;
-	}
-
-	private synchronized boolean _unregisterMessageListener(
-		String destinationName, MessageListener messageListener) {
-
-		Destination destination = _destinations.get(destinationName);
-
-		if (destination != null) {
-			return destination.unregister(messageListener);
-		}
-
-		List<MessageListener> queuedMessageListeners =
-			_queuedMessageListeners.get(destinationName);
-
-		if (ListUtil.isEmpty(queuedMessageListeners)) {
-			return false;
-		}
-
-		return queuedMessageListeners.remove(messageListener);
 	}
 
 	private void _updateDestination(
@@ -459,11 +264,6 @@ public class DefaultMessageBus implements MessageBus {
 		new ConcurrentHashMap<>();
 	private final Set<MessageBusEventListener> _messageBusEventListeners =
 		Collections.newSetFromMap(new ConcurrentHashMap<>());
-	private ServiceTracker
-		<MessageListener, ObjectValuePair<String, MessageListener>>
-			_messageListenerServiceTracker;
-	private final Map<String, List<MessageListener>> _queuedMessageListeners =
-		new HashMap<>();
 	private ServiceRegistration<ManagedServiceFactory> _serviceRegistration;
 	private ServiceTrackerList<MessageBusInterceptor> _serviceTrackerList;
 

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java
@@ -191,8 +191,6 @@ public class DefaultMessageBus implements MessageBus {
 		_destinationServiceTrackerMap.close();
 
 		_messageBusEventListenerServiceTrackerList.close();
-
-		shutdown(true);
 	}
 
 	private void _updateDestination(

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java
@@ -7,6 +7,9 @@ package com.liferay.portal.messaging.internal;
 
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapListener;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -17,7 +20,6 @@ import com.liferay.portal.kernel.messaging.MessageBusEventListener;
 import com.liferay.portal.kernel.messaging.MessageBusInterceptor;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
-import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.messaging.internal.configuration.DestinationWorkerConfiguration;
 
 import java.util.Dictionary;
@@ -32,10 +34,6 @@ import org.osgi.service.cm.ManagedServiceFactory;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Michael C. Han
@@ -46,7 +44,7 @@ public class DefaultMessageBus implements MessageBus {
 
 	@Override
 	public Destination getDestination(String destinationName) {
-		return _destinations.get(destinationName);
+		return _destinationServiceTrackerMap.getService(destinationName);
 	}
 
 	@Override
@@ -63,7 +61,8 @@ public class DefaultMessageBus implements MessageBus {
 			}
 		}
 
-		Destination destination = _destinations.get(destinationName);
+		Destination destination = _destinationServiceTrackerMap.getService(
+			destinationName);
 
 		if (destination == null) {
 			if (_log.isWarnEnabled()) {
@@ -109,7 +108,7 @@ public class DefaultMessageBus implements MessageBus {
 
 	@Override
 	public synchronized void shutdown(boolean force) {
-		for (Destination destination : _destinations.values()) {
+		for (Destination destination : _destinationServiceTrackerMap.values()) {
 			destination.close(force);
 		}
 	}
@@ -129,6 +128,55 @@ public class DefaultMessageBus implements MessageBus {
 			ServiceTrackerListFactory.open(
 				bundleContext, MessageBusEventListener.class);
 
+		_destinationServiceTrackerMap =
+			ServiceTrackerMapFactory.openSingleValueMap(
+				bundleContext, Destination.class, "destination.name",
+				new ServiceTrackerMapListener
+					<String, Destination, Destination>() {
+
+					@Override
+					public void keyEmitted(
+						ServiceTrackerMap<String, Destination>
+							serviceTrackerMap,
+						String key, Destination destination,
+						Destination content) {
+
+						destination.open();
+
+						for (MessageBusEventListener messageBusEventListener :
+								_messageBusEventListenerServiceTrackerList) {
+
+							messageBusEventListener.destinationAdded(
+								destination);
+						}
+
+						DestinationWorkerConfiguration
+							destinationWorkerConfiguration =
+								_destinationWorkerConfigurations.get(key);
+
+						_updateDestination(
+							destination, destinationWorkerConfiguration);
+					}
+
+					@Override
+					public void keyRemoved(
+						ServiceTrackerMap<String, Destination>
+							serviceTrackerMap,
+						String key, Destination destination,
+						Destination content) {
+
+						destination.destroy();
+
+						for (MessageBusEventListener messageBusEventListener :
+								_messageBusEventListenerServiceTrackerList) {
+
+							messageBusEventListener.destinationRemoved(
+								destination);
+						}
+					}
+
+				});
+
 		_serviceTrackerList = ServiceTrackerListFactory.open(
 			bundleContext, MessageBusInterceptor.class);
 	}
@@ -137,85 +185,13 @@ public class DefaultMessageBus implements MessageBus {
 	protected void deactivate() {
 		_serviceTrackerList.close();
 
+		_destinationServiceTrackerMap.close();
+
 		_messageBusEventListenerServiceTrackerList.close();
 
 		_serviceRegistration.unregister();
 
 		shutdown(true);
-
-		for (Destination destination : _destinations.values()) {
-			destination.destroy();
-		}
-
-		_destinations.clear();
-	}
-
-	@Reference(
-		cardinality = ReferenceCardinality.MULTIPLE,
-		policy = ReferencePolicy.DYNAMIC,
-		policyOption = ReferencePolicyOption.GREEDY,
-		target = "(destination.name=*)"
-	)
-	protected synchronized void registerDestination(
-		Destination destination, Map<String, Object> properties) {
-
-		String destinationName = MapUtil.getString(
-			properties, "destination.name");
-
-		_addDestination(destination);
-
-		DestinationWorkerConfiguration destinationWorkerConfiguration =
-			_destinationWorkerConfigurations.get(destinationName);
-
-		_updateDestination(destination, destinationWorkerConfiguration);
-	}
-
-	protected synchronized void unregisterDestination(
-		Destination destination, Map<String, Object> properties) {
-
-		_removeDestination(destination.getName());
-	}
-
-	private void _addDestination(Destination destination) {
-		Destination oldDestination = _destinations.get(destination.getName());
-
-		destination.open();
-
-		_destinations.put(destination.getName(), destination);
-
-		if (oldDestination != null) {
-			oldDestination.destroy();
-
-			for (MessageBusEventListener messageBusEventListener :
-					_messageBusEventListenerServiceTrackerList) {
-
-				messageBusEventListener.destinationRemoved(oldDestination);
-			}
-		}
-
-		for (MessageBusEventListener messageBusEventListener :
-				_messageBusEventListenerServiceTrackerList) {
-
-			messageBusEventListener.destinationAdded(destination);
-		}
-	}
-
-	private Destination _removeDestination(String destinationName) {
-		Destination destination = _destinations.remove(destinationName);
-
-		if (destination == null) {
-			return null;
-		}
-
-		destination.destroy();
-
-		for (MessageBusEventListener messageBusEventListener :
-				_messageBusEventListenerServiceTrackerList) {
-
-			messageBusEventListener.destinationRemoved(destination);
-		}
-
-		return destination;
 	}
 
 	private void _updateDestination(
@@ -241,8 +217,8 @@ public class DefaultMessageBus implements MessageBus {
 	private static final Log _log = LogFactoryUtil.getLog(
 		DefaultMessageBus.class);
 
-	private final Map<String, Destination> _destinations =
-		new ConcurrentHashMap<>();
+	private ServiceTrackerMap<String, Destination>
+		_destinationServiceTrackerMap;
 	private final Map<String, DestinationWorkerConfiguration>
 		_destinationWorkerConfigurations = new ConcurrentHashMap<>();
 	private final Map<String, String> _factoryPidsToDestinationNames =
@@ -283,7 +259,7 @@ public class DefaultMessageBus implements MessageBus {
 				destinationWorkerConfiguration.destinationName(),
 				destinationWorkerConfiguration);
 
-			Destination destination = _destinations.get(
+			Destination destination = _destinationServiceTrackerMap.getService(
 				destinationWorkerConfiguration.destinationName());
 
 			_updateDestination(destination, destinationWorkerConfiguration);

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java
@@ -101,18 +101,6 @@ public class DefaultMessageBus implements MessageBus {
 		destination.send(message);
 	}
 
-	@Override
-	public void shutdown() {
-		shutdown(false);
-	}
-
-	@Override
-	public synchronized void shutdown(boolean force) {
-		for (Destination destination : _destinationServiceTrackerMap.values()) {
-			destination.close(force);
-		}
-	}
-
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_messageBusEventListenerServiceTrackerList =

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java
@@ -52,7 +52,7 @@ public class DefaultMessageBus implements MessageBus {
 		MessageBusThreadLocalUtil.populateMessageFromThreadLocals(message);
 
 		for (MessageBusInterceptor messageBusInterceptor :
-				_serviceTrackerList) {
+				_messageBusInterceptorServiceTrackerList) {
 
 			if (messageBusInterceptor.intercept(
 					this, destinationName, message)) {
@@ -177,13 +177,14 @@ public class DefaultMessageBus implements MessageBus {
 					"DestinationWorkerConfiguration"
 			).build());
 
-		_serviceTrackerList = ServiceTrackerListFactory.open(
-			bundleContext, MessageBusInterceptor.class);
+		_messageBusInterceptorServiceTrackerList =
+			ServiceTrackerListFactory.open(
+				bundleContext, MessageBusInterceptor.class);
 	}
 
 	@Deactivate
 	protected void deactivate() {
-		_serviceTrackerList.close();
+		_messageBusInterceptorServiceTrackerList.close();
 
 		_serviceRegistration.unregister();
 
@@ -225,8 +226,9 @@ public class DefaultMessageBus implements MessageBus {
 		new ConcurrentHashMap<>();
 	private ServiceTrackerList<MessageBusEventListener>
 		_messageBusEventListenerServiceTrackerList;
+	private ServiceTrackerList<MessageBusInterceptor>
+		_messageBusInterceptorServiceTrackerList;
 	private ServiceRegistration<ManagedServiceFactory> _serviceRegistration;
-	private ServiceTrackerList<MessageBusInterceptor> _serviceTrackerList;
 
 	private class DefaultMessageBusManagedServiceFactory
 		implements ManagedServiceFactory {

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java
@@ -20,10 +20,8 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.messaging.internal.configuration.DestinationWorkerConfiguration;
 
-import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.framework.BundleContext;
@@ -127,6 +125,10 @@ public class DefaultMessageBus implements MessageBus {
 					"DestinationWorkerConfiguration"
 			).build());
 
+		_messageBusEventListenerServiceTrackerList =
+			ServiceTrackerListFactory.open(
+				bundleContext, MessageBusEventListener.class);
+
 		_serviceTrackerList = ServiceTrackerListFactory.open(
 			bundleContext, MessageBusInterceptor.class);
 	}
@@ -135,9 +137,9 @@ public class DefaultMessageBus implements MessageBus {
 	protected void deactivate() {
 		_serviceTrackerList.close();
 
-		_serviceRegistration.unregister();
+		_messageBusEventListenerServiceTrackerList.close();
 
-		_messageBusEventListeners.clear();
+		_serviceRegistration.unregister();
 
 		shutdown(true);
 
@@ -168,27 +170,10 @@ public class DefaultMessageBus implements MessageBus {
 		_updateDestination(destination, destinationWorkerConfiguration);
 	}
 
-	@Reference(
-		cardinality = ReferenceCardinality.MULTIPLE,
-		policy = ReferencePolicy.DYNAMIC,
-		policyOption = ReferencePolicyOption.GREEDY
-	)
-	protected void registerMessageBusEventListener(
-		MessageBusEventListener messageBusEventListener) {
-
-		_messageBusEventListeners.add(messageBusEventListener);
-	}
-
 	protected synchronized void unregisterDestination(
 		Destination destination, Map<String, Object> properties) {
 
 		_removeDestination(destination.getName());
-	}
-
-	protected void unregisterMessageBusEventListener(
-		MessageBusEventListener messageBusEventListener) {
-
-		_messageBusEventListeners.remove(messageBusEventListener);
 	}
 
 	private void _addDestination(Destination destination) {
@@ -202,14 +187,14 @@ public class DefaultMessageBus implements MessageBus {
 			oldDestination.destroy();
 
 			for (MessageBusEventListener messageBusEventListener :
-					_messageBusEventListeners) {
+					_messageBusEventListenerServiceTrackerList) {
 
 				messageBusEventListener.destinationRemoved(oldDestination);
 			}
 		}
 
 		for (MessageBusEventListener messageBusEventListener :
-				_messageBusEventListeners) {
+				_messageBusEventListenerServiceTrackerList) {
 
 			messageBusEventListener.destinationAdded(destination);
 		}
@@ -225,7 +210,7 @@ public class DefaultMessageBus implements MessageBus {
 		destination.destroy();
 
 		for (MessageBusEventListener messageBusEventListener :
-				_messageBusEventListeners) {
+				_messageBusEventListenerServiceTrackerList) {
 
 			messageBusEventListener.destinationRemoved(destination);
 		}
@@ -262,8 +247,8 @@ public class DefaultMessageBus implements MessageBus {
 		_destinationWorkerConfigurations = new ConcurrentHashMap<>();
 	private final Map<String, String> _factoryPidsToDestinationNames =
 		new ConcurrentHashMap<>();
-	private final Set<MessageBusEventListener> _messageBusEventListeners =
-		Collections.newSetFromMap(new ConcurrentHashMap<>());
+	private ServiceTrackerList<MessageBusEventListener>
+		_messageBusEventListenerServiceTrackerList;
 	private ServiceRegistration<ManagedServiceFactory> _serviceRegistration;
 	private ServiceTrackerList<MessageBusInterceptor> _serviceTrackerList;
 

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java
@@ -115,15 +115,6 @@ public class DefaultMessageBus implements MessageBus {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		_serviceRegistration = bundleContext.registerService(
-			ManagedServiceFactory.class,
-			new DefaultMessageBusManagedServiceFactory(),
-			HashMapDictionaryBuilder.put(
-				Constants.SERVICE_PID,
-				"com.liferay.portal.messaging.internal.configuration." +
-					"DestinationWorkerConfiguration"
-			).build());
-
 		_messageBusEventListenerServiceTrackerList =
 			ServiceTrackerListFactory.open(
 				bundleContext, MessageBusEventListener.class);
@@ -177,6 +168,15 @@ public class DefaultMessageBus implements MessageBus {
 
 				});
 
+		_serviceRegistration = bundleContext.registerService(
+			ManagedServiceFactory.class,
+			new DefaultMessageBusManagedServiceFactory(),
+			HashMapDictionaryBuilder.put(
+				Constants.SERVICE_PID,
+				"com.liferay.portal.messaging.internal.configuration." +
+					"DestinationWorkerConfiguration"
+			).build());
+
 		_serviceTrackerList = ServiceTrackerListFactory.open(
 			bundleContext, MessageBusInterceptor.class);
 	}
@@ -185,11 +185,11 @@ public class DefaultMessageBus implements MessageBus {
 	protected void deactivate() {
 		_serviceTrackerList.close();
 
+		_serviceRegistration.unregister();
+
 		_destinationServiceTrackerMap.close();
 
 		_messageBusEventListenerServiceTrackerList.close();
-
-		_serviceRegistration.unregister();
 
 		shutdown(true);
 	}

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java
@@ -328,8 +328,11 @@ public class DefaultMessageBus implements MessageBus {
 							destination.getName()));
 				}
 
+				Thread currentThread = Thread.currentThread();
+
 				for (MessageListener messageListener : messageListeners) {
-					destination.register(messageListener);
+					destination.register(
+						messageListener, currentThread.getContextClassLoader());
 				}
 			}
 		}
@@ -361,7 +364,10 @@ public class DefaultMessageBus implements MessageBus {
 		Destination destination = _destinations.get(destinationName);
 
 		if (destination != null) {
-			return destination.register(messageListener);
+			Thread currentThread = Thread.currentThread();
+
+			return destination.register(
+				messageListener, currentThread.getContextClassLoader());
 		}
 
 		List<MessageListener> queuedMessageListeners =

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/MessageListenerRegistryImpl.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/MessageListenerRegistryImpl.java
@@ -1,0 +1,125 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.messaging.internal;
+
+import com.liferay.osgi.service.tracker.collections.map.PropertyServiceReferenceMapper;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapListener;
+import com.liferay.portal.kernel.messaging.DestinationEventListener;
+import com.liferay.portal.kernel.messaging.InvokerMessageListener;
+import com.liferay.portal.kernel.messaging.MessageListener;
+import com.liferay.portal.kernel.messaging.MessageListenerRegistry;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
+
+/**
+ * @author Dante Wang
+ */
+@Component(service = MessageListenerRegistry.class)
+public class MessageListenerRegistryImpl implements MessageListenerRegistry {
+
+	public List<MessageListener> getMessageListeners(String destinationName) {
+		return _messageListenerServiceTrackerMap.getService(destinationName);
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_destinationEventListenerServiceTrackerMap =
+			ServiceTrackerMapFactory.openMultiValueMap(
+				bundleContext, DestinationEventListener.class,
+				"destination.name");
+
+		_messageListenerServiceTrackerMap =
+			ServiceTrackerMapFactory.openMultiValueMap(
+				bundleContext, MessageListener.class, "(destination.name=*)",
+				new PropertyServiceReferenceMapper<>("destination.name"),
+				new ServiceTrackerCustomizer
+					<MessageListener, MessageListener>() {
+
+					@Override
+					public MessageListener addingService(
+						ServiceReference<MessageListener> serviceReference) {
+
+						return new InvokerMessageListener(
+							bundleContext.getService(serviceReference));
+					}
+
+					@Override
+					public void modifiedService(
+						ServiceReference<MessageListener> serviceReference,
+						MessageListener messageListener) {
+					}
+
+					@Override
+					public void removedService(
+						ServiceReference<MessageListener> serviceReference,
+						MessageListener messageListener) {
+
+						bundleContext.ungetService(serviceReference);
+					}
+
+				},
+				Collections.reverseOrder(),
+				new ServiceTrackerMapListener
+					<String, MessageListener, List<MessageListener>>() {
+
+					@Override
+					public void keyEmitted(
+						ServiceTrackerMap<String, List<MessageListener>>
+							serviceTrackerMap,
+						String key, MessageListener messageListener,
+						List<MessageListener> messageListeners) {
+
+						for (DestinationEventListener destinationEventListener :
+								_destinationEventListenerServiceTrackerMap.
+									getService(key)) {
+
+							destinationEventListener.messageListenerRegistered(
+								key, messageListener);
+						}
+					}
+
+					@Override
+					public void keyRemoved(
+						ServiceTrackerMap<String, List<MessageListener>>
+							serviceTrackerMap,
+						String key, MessageListener messageListener,
+						List<MessageListener> messageListeners) {
+
+						for (DestinationEventListener destinationEventListener :
+								_destinationEventListenerServiceTrackerMap.
+									getService(key)) {
+
+							destinationEventListener.
+								messageListenerUnregistered(
+									key, messageListener);
+						}
+					}
+
+				});
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_messageListenerServiceTrackerMap.close();
+		_destinationEventListenerServiceTrackerMap.close();
+	}
+
+	private ServiceTrackerMap<String, List<DestinationEventListener>>
+		_destinationEventListenerServiceTrackerMap;
+	private ServiceTrackerMap<String, List<MessageListener>>
+		_messageListenerServiceTrackerMap;
+
+}

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/MessageListenerRegistryImpl.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/MessageListenerRegistryImpl.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -31,7 +31,14 @@ import org.osgi.util.tracker.ServiceTrackerCustomizer;
 public class MessageListenerRegistryImpl implements MessageListenerRegistry {
 
 	public List<MessageListener> getMessageListeners(String destinationName) {
-		return _messageListenerServiceTrackerMap.getService(destinationName);
+		List<MessageListener> messageListeners =
+			_messageListenerServiceTrackerMap.getService(destinationName);
+
+		if (messageListeners == null) {
+			return Collections.emptyList();
+		}
+
+		return messageListeners;
 	}
 
 	@Activate
@@ -82,9 +89,17 @@ public class MessageListenerRegistryImpl implements MessageListenerRegistry {
 						String key, MessageListener messageListener,
 						List<MessageListener> messageListeners) {
 
-						for (DestinationEventListener destinationEventListener :
+						List<DestinationEventListener>
+							destinationEventListeners =
 								_destinationEventListenerServiceTrackerMap.
-									getService(key)) {
+									getService(key);
+
+						if (destinationEventListeners == null) {
+							return;
+						}
+
+						for (DestinationEventListener destinationEventListener :
+								destinationEventListeners) {
 
 							destinationEventListener.messageListenerRegistered(
 								key, messageListener);
@@ -98,9 +113,17 @@ public class MessageListenerRegistryImpl implements MessageListenerRegistry {
 						String key, MessageListener messageListener,
 						List<MessageListener> messageListeners) {
 
-						for (DestinationEventListener destinationEventListener :
+						List<DestinationEventListener>
+							destinationEventListeners =
 								_destinationEventListenerServiceTrackerMap.
-									getService(key)) {
+									getService(key);
+
+						if (destinationEventListeners == null) {
+							return;
+						}
+
+						for (DestinationEventListener destinationEventListener :
+								destinationEventListeners) {
 
 							destinationEventListener.
 								messageListenerUnregistered(

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/ParallelDestination.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/ParallelDestination.java
@@ -15,7 +15,7 @@ import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.messaging.MessageListenerException;
 import com.liferay.portal.kernel.messaging.MessageRunnable;
 
-import java.util.Set;
+import java.util.List;
 
 /**
  * <p>
@@ -29,7 +29,7 @@ public class ParallelDestination extends BaseAsyncDestination {
 
 	@Override
 	protected void dispatch(
-		Set<MessageListener> messageListeners, final Message message) {
+		List<MessageListener> messageListeners, final Message message) {
 
 		Thread currentThread = Thread.currentThread();
 

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/ParallelDestinationPrototype.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/ParallelDestinationPrototype.java
@@ -8,6 +8,7 @@ package com.liferay.portal.messaging.internal;
 import com.liferay.petra.executor.PortalExecutorManager;
 import com.liferay.portal.kernel.messaging.Destination;
 import com.liferay.portal.kernel.messaging.DestinationConfiguration;
+import com.liferay.portal.kernel.messaging.MessageListenerRegistry;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.service.UserLocalService;
 
@@ -19,11 +20,13 @@ public class ParallelDestinationPrototype implements DestinationPrototype {
 	public ParallelDestinationPrototype(
 		PortalExecutorManager portalExecutorManager,
 		PermissionCheckerFactory permissionCheckerFactory,
-		UserLocalService userLocalService) {
+		UserLocalService userLocalService,
+		MessageListenerRegistry messageListenerRegistry) {
 
 		_portalExecutorManager = portalExecutorManager;
 		_permissionCheckerFactory = permissionCheckerFactory;
 		_userLocalService = userLocalService;
+		_messageListenerRegistry = messageListenerRegistry;
 	}
 
 	@Override
@@ -38,6 +41,8 @@ public class ParallelDestinationPrototype implements DestinationPrototype {
 			destinationConfiguration.getDestinationName());
 		parallelDestination.setMaximumQueueSize(
 			destinationConfiguration.getMaximumQueueSize());
+		parallelDestination.setMessageListenerRegistry(
+			_messageListenerRegistry);
 		parallelDestination.setPermissionCheckerFactory(
 			_permissionCheckerFactory);
 		parallelDestination.setPortalExecutorManager(_portalExecutorManager);
@@ -51,6 +56,7 @@ public class ParallelDestinationPrototype implements DestinationPrototype {
 		return parallelDestination;
 	}
 
+	private final MessageListenerRegistry _messageListenerRegistry;
 	private final PermissionCheckerFactory _permissionCheckerFactory;
 	private final PortalExecutorManager _portalExecutorManager;
 	private final UserLocalService _userLocalService;

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/SerialDestination.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/SerialDestination.java
@@ -15,7 +15,7 @@ import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.messaging.MessageListenerException;
 import com.liferay.portal.kernel.messaging.MessageRunnable;
 
-import java.util.Set;
+import java.util.List;
 
 /**
  * <p>
@@ -33,7 +33,7 @@ public class SerialDestination extends BaseAsyncDestination {
 
 	@Override
 	protected void dispatch(
-		Set<MessageListener> messageListeners, final Message message) {
+		List<MessageListener> messageListeners, final Message message) {
 
 		Thread currentThread = Thread.currentThread();
 

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/SerialDestinationPrototype.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/SerialDestinationPrototype.java
@@ -8,6 +8,7 @@ package com.liferay.portal.messaging.internal;
 import com.liferay.petra.executor.PortalExecutorManager;
 import com.liferay.portal.kernel.messaging.Destination;
 import com.liferay.portal.kernel.messaging.DestinationConfiguration;
+import com.liferay.portal.kernel.messaging.MessageListenerRegistry;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.service.UserLocalService;
 
@@ -19,11 +20,13 @@ public class SerialDestinationPrototype implements DestinationPrototype {
 	public SerialDestinationPrototype(
 		PortalExecutorManager portalExecutorManager,
 		PermissionCheckerFactory permissionCheckerFactory,
-		UserLocalService userLocalService) {
+		UserLocalService userLocalService,
+		MessageListenerRegistry messageListenerRegistry) {
 
 		_portalExecutorManager = portalExecutorManager;
 		_permissionCheckerFactory = permissionCheckerFactory;
 		_userLocalService = userLocalService;
+		_messageListenerRegistry = messageListenerRegistry;
 	}
 
 	@Override
@@ -38,6 +41,7 @@ public class SerialDestinationPrototype implements DestinationPrototype {
 			destinationConfiguration.getDestinationName());
 		serialDestination.setMaximumQueueSize(
 			destinationConfiguration.getMaximumQueueSize());
+		serialDestination.setMessageListenerRegistry(_messageListenerRegistry);
 		serialDestination.setPermissionCheckerFactory(
 			_permissionCheckerFactory);
 		serialDestination.setPortalExecutorManager(_portalExecutorManager);
@@ -53,6 +57,7 @@ public class SerialDestinationPrototype implements DestinationPrototype {
 
 	private static final int _WORKERS_MAX_SIZE = 1;
 
+	private final MessageListenerRegistry _messageListenerRegistry;
 	private final PermissionCheckerFactory _permissionCheckerFactory;
 	private final PortalExecutorManager _portalExecutorManager;
 	private final UserLocalService _userLocalService;

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/SynchronousDestination.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/SynchronousDestination.java
@@ -50,7 +50,9 @@ public class SynchronousDestination extends BaseDestination {
 	}
 
 	private void _send(Message message) {
-		for (MessageListener messageListener : messageListeners) {
+		for (MessageListener messageListener :
+				messageListenerRegistry.getMessageListeners(name)) {
+
 			try {
 				messageListener.receive(message);
 			}

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/SynchronousDestinationPrototype.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/SynchronousDestinationPrototype.java
@@ -7,11 +7,18 @@ package com.liferay.portal.messaging.internal;
 
 import com.liferay.portal.kernel.messaging.Destination;
 import com.liferay.portal.kernel.messaging.DestinationConfiguration;
+import com.liferay.portal.kernel.messaging.MessageListenerRegistry;
 
 /**
  * @author Michael C. Han
  */
 public class SynchronousDestinationPrototype implements DestinationPrototype {
+
+	public SynchronousDestinationPrototype(
+		MessageListenerRegistry messageListenerRegistry) {
+
+		_messageListenerRegistry = messageListenerRegistry;
+	}
 
 	@Override
 	public Destination createDestination(
@@ -22,10 +29,14 @@ public class SynchronousDestinationPrototype implements DestinationPrototype {
 
 		synchronousDestination.setDestinationType(
 			destinationConfiguration.getDestinationType());
+		synchronousDestination.setMessageListenerRegistry(
+			_messageListenerRegistry);
 		synchronousDestination.setName(
 			destinationConfiguration.getDestinationName());
 
 		return synchronousDestination;
 	}
+
+	private final MessageListenerRegistry _messageListenerRegistry;
 
 }

--- a/modules/apps/portal/portal-messaging/src/test/java/com/liferay/portal/messaging/internal/MessageListenerRegistryImplTest.java
+++ b/modules/apps/portal/portal-messaging/src/test/java/com/liferay/portal/messaging/internal/MessageListenerRegistryImplTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/portal/portal-messaging/src/test/java/com/liferay/portal/messaging/internal/MessageListenerRegistryImplTest.java
+++ b/modules/apps/portal/portal-messaging/src/test/java/com/liferay/portal/messaging/internal/MessageListenerRegistryImplTest.java
@@ -1,0 +1,129 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.messaging.internal;
+
+import com.liferay.portal.kernel.messaging.DestinationEventListener;
+import com.liferay.portal.kernel.messaging.MessageListener;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Dante Wang
+ */
+public class MessageListenerRegistryImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_messageListenerRegistryImpl.activate(_bundleContext);
+	}
+
+	@After
+	public void tearDown() {
+		_messageListenerRegistryImpl.deactivate();
+	}
+
+	@Test
+	public void testRegisterUnregisterMessageListener() {
+		List<MessageListener> eventNotifiedMessageListeners = new ArrayList<>();
+
+		ServiceRegistration<DestinationEventListener> serviceRegistration1 =
+			_bundleContext.registerService(
+				DestinationEventListener.class,
+				new DestinationEventListener() {
+
+					@Override
+					public void messageListenerRegistered(
+						String destinationName,
+						MessageListener messageListener) {
+
+						eventNotifiedMessageListeners.add(messageListener);
+					}
+
+					@Override
+					public void messageListenerUnregistered(
+						String destinationName,
+						MessageListener messageListener) {
+
+						eventNotifiedMessageListeners.remove(messageListener);
+					}
+
+				},
+				HashMapDictionaryBuilder.put(
+					"destination.name", "test"
+				).build());
+
+		ServiceRegistration<MessageListener> serviceRegistration2 =
+			_bundleContext.registerService(
+				MessageListener.class,
+				message -> {
+				},
+				HashMapDictionaryBuilder.put(
+					"destination.name", "test"
+				).build());
+		ServiceRegistration<MessageListener> serviceRegistration3 =
+			_bundleContext.registerService(
+				MessageListener.class,
+				message -> {
+				},
+				HashMapDictionaryBuilder.put(
+					"destination.name", "test"
+				).build());
+
+		try {
+			List<MessageListener> messageListeners =
+				_messageListenerRegistryImpl.getMessageListeners("test");
+
+			Assert.assertEquals(
+				messageListeners.toString(), 2, messageListeners.size());
+
+			Assert.assertEquals(
+				eventNotifiedMessageListeners.toString(), 2,
+				eventNotifiedMessageListeners.size());
+
+			serviceRegistration3.unregister();
+
+			messageListeners = _messageListenerRegistryImpl.getMessageListeners(
+				"test");
+
+			Assert.assertEquals(
+				messageListeners.toString(), 1, messageListeners.size());
+
+			Assert.assertEquals(
+				eventNotifiedMessageListeners.toString(), 1,
+				eventNotifiedMessageListeners.size());
+		}
+		finally {
+			serviceRegistration2.unregister();
+			serviceRegistration1.unregister();
+		}
+	}
+
+	private static final BundleContext _bundleContext =
+		SystemBundleUtil.getBundleContext();
+
+	private final MessageListenerRegistryImpl _messageListenerRegistryImpl =
+		new MessageListenerRegistryImpl();
+
+}

--- a/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-apple/src/main/java/com/liferay/push/notifications/sender/apple/internal/messaging/ApplePushNotificationsMessagingConfigurator.java
+++ b/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-apple/src/main/java/com/liferay/push/notifications/sender/apple/internal/messaging/ApplePushNotificationsMessagingConfigurator.java
@@ -5,15 +5,15 @@
 
 package com.liferay.push.notifications.sender.apple.internal.messaging;
 
-import com.liferay.portal.kernel.messaging.Destination;
 import com.liferay.portal.kernel.messaging.MessageListener;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.push.notifications.constants.PushNotificationsDestinationNames;
 
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Bruno Farache
@@ -25,22 +25,19 @@ public class ApplePushNotificationsMessagingConfigurator {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		_applePushNotificationsResponseMessageListener =
-			new ApplePushNotificationsResponseMessageListener();
-
-		_destination.register(_applePushNotificationsResponseMessageListener);
+		_serviceRegistration = bundleContext.registerService(
+			MessageListener.class,
+			new ApplePushNotificationsResponseMessageListener(),
+			MapUtil.singletonDictionary(
+				"destination.name",
+				PushNotificationsDestinationNames.PUSH_NOTIFICATION_RESPONSE));
 	}
 
 	@Deactivate
 	protected void deactivate() {
-		_destination.unregister(_applePushNotificationsResponseMessageListener);
+		_serviceRegistration.unregister();
 	}
 
-	private MessageListener _applePushNotificationsResponseMessageListener;
-
-	@Reference(
-		target = "(destination.name= " + PushNotificationsDestinationNames.PUSH_NOTIFICATION_RESPONSE + ")"
-	)
-	private Destination _destination;
+	private ServiceRegistration<MessageListener> _serviceRegistration;
 
 }

--- a/modules/apps/push-notifications/push-notifications-service/src/main/java/com/liferay/push/notifications/internal/messaging/PushNotificationMessagingConfigurator.java
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/java/com/liferay/push/notifications/internal/messaging/PushNotificationMessagingConfigurator.java
@@ -33,43 +33,21 @@ public class PushNotificationMessagingConfigurator {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		_bundleContext = bundleContext;
-
-		DestinationConfiguration pushNotificationDestinationConfiguration =
-			new DestinationConfiguration(
-				DestinationConfiguration.DESTINATION_TYPE_SERIAL,
-				PushNotificationsDestinationNames.PUSH_NOTIFICATION);
-
-		Destination pushNotificationDestination = _registerDestination(
-			pushNotificationDestinationConfiguration);
-
-		MessageListener pushNotificationsMessageListener =
+		_registerMessaging(
+			bundleContext, PushNotificationsDestinationNames.PUSH_NOTIFICATION,
 			new PushNotificationsMessageListener(
-				_pushNotificationsDeviceLocalService);
+				_pushNotificationsDeviceLocalService));
 
-		pushNotificationDestination.register(pushNotificationsMessageListener);
-
-		DestinationConfiguration
-			pushNotificationResponseDestinationConfiguration =
-				new DestinationConfiguration(
-					DestinationConfiguration.DESTINATION_TYPE_SERIAL,
-					PushNotificationsDestinationNames.
-						PUSH_NOTIFICATION_RESPONSE);
-
-		Destination pushNotificationResponseDestination = _registerDestination(
-			pushNotificationResponseDestinationConfiguration);
-
-		MessageListener pushNotificationsResponseMessageListener =
-			new PushNotificationsResponseMessageListener(_jsonFactory);
-
-		pushNotificationResponseDestination.register(
-			pushNotificationsResponseMessageListener);
+		_registerMessaging(
+			bundleContext,
+			PushNotificationsDestinationNames.PUSH_NOTIFICATION_RESPONSE,
+			new PushNotificationsResponseMessageListener(_jsonFactory));
 	}
 
 	@Deactivate
 	protected void deactivate() {
 		if (!_serviceRegistrations.isEmpty()) {
-			for (ServiceRegistration<Destination> serviceRegistration :
+			for (ServiceRegistration<?> serviceRegistration :
 					_serviceRegistrations) {
 
 				serviceRegistration.unregister();
@@ -77,29 +55,30 @@ public class PushNotificationMessagingConfigurator {
 
 			_serviceRegistrations.clear();
 		}
-
-		_bundleContext = null;
 	}
 
-	private Destination _registerDestination(
-		DestinationConfiguration destinationConfiguration) {
+	private void _registerMessaging(
+		BundleContext bundleContext, String destinationName,
+		MessageListener messageListener) {
 
 		Destination destination = _destinationFactory.createDestination(
-			destinationConfiguration);
+			new DestinationConfiguration(
+				DestinationConfiguration.DESTINATION_TYPE_SERIAL,
+				destinationName));
 
-		Dictionary<String, Object> properties =
+		Dictionary<String, Object> dictionary =
 			HashMapDictionaryBuilder.<String, Object>put(
 				"destination.name", destination.getName()
 			).build();
 
 		_serviceRegistrations.add(
-			_bundleContext.registerService(
-				Destination.class, destination, properties));
+			bundleContext.registerService(
+				Destination.class, destination, dictionary));
 
-		return destination;
+		_serviceRegistrations.add(
+			bundleContext.registerService(
+				MessageListener.class, messageListener, dictionary));
 	}
-
-	private BundleContext _bundleContext;
 
 	@Reference
 	private DestinationFactory _destinationFactory;
@@ -111,7 +90,7 @@ public class PushNotificationMessagingConfigurator {
 	private PushNotificationsDeviceLocalService
 		_pushNotificationsDeviceLocalService;
 
-	private final List<ServiceRegistration<Destination>> _serviceRegistrations =
+	private final List<ServiceRegistration<?>> _serviceRegistrations =
 		new ArrayList<>();
 
 }

--- a/portal-impl/src/com/liferay/portal/events/GlobalShutdownAction.java
+++ b/portal-impl/src/com/liferay/portal/events/GlobalShutdownAction.java
@@ -13,7 +13,6 @@ import com.liferay.portal.kernel.events.SimpleAction;
 import com.liferay.portal.kernel.log.Jdk14LogFactoryImpl;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.messaging.MessageBusUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.struts.AuthPublicPathRegistry;
@@ -84,10 +83,6 @@ public class GlobalShutdownAction extends SimpleAction {
 	}
 
 	protected void shutdownLevel3() {
-
-		// Messaging
-
-		MessageBusUtil.shutdown(true);
 	}
 
 	protected void shutdownLevel4() {

--- a/portal-kernel/src/com/liferay/portal/kernel/messaging/BaseDestination.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/messaging/BaseDestination.java
@@ -133,6 +133,12 @@ public abstract class BaseDestination implements Destination {
 		_destinationType = destinationType;
 	}
 
+	public void setMessageListenerRegistry(
+		MessageListenerRegistry messageListenerRegistry) {
+
+		this.messageListenerRegistry = messageListenerRegistry;
+	}
+
 	public void setName(String name) {
 		this.name = name;
 	}
@@ -206,6 +212,7 @@ public abstract class BaseDestination implements Destination {
 		return unregistered;
 	}
 
+	protected MessageListenerRegistry messageListenerRegistry;
 	protected Set<MessageListener> messageListeners = Collections.newSetFromMap(
 		new ConcurrentHashMap<>());
 	protected String name = StringPool.BLANK;

--- a/portal-kernel/src/com/liferay/portal/kernel/messaging/BaseDestination.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/messaging/BaseDestination.java
@@ -8,8 +8,9 @@ package com.liferay.portal.kernel.messaging;
 import com.liferay.petra.string.StringPool;
 
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Michael C. Han
@@ -17,13 +18,6 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Brian Wing Shun Chan
  */
 public abstract class BaseDestination implements Destination {
-
-	@Override
-	public boolean addDestinationEventListener(
-		DestinationEventListener destinationEventListener) {
-
-		return _destinationEventListeners.add(destinationEventListener);
-	}
 
 	@Override
 	public void close() {
@@ -35,33 +29,8 @@ public abstract class BaseDestination implements Destination {
 	}
 
 	@Override
-	public void copyDestinationEventListeners(Destination destination) {
-		for (DestinationEventListener destinationEventListener :
-				_destinationEventListeners) {
-
-			destination.addDestinationEventListener(destinationEventListener);
-		}
-	}
-
-	@Override
-	public void copyMessageListeners(Destination destination) {
-		for (MessageListener messageListener : messageListeners) {
-			InvokerMessageListener invokerMessageListener =
-				(InvokerMessageListener)messageListener;
-
-			destination.register(
-				invokerMessageListener.getMessageListener(),
-				invokerMessageListener.getClassLoader());
-		}
-	}
-
-	@Override
 	public void destroy() {
 		close(true);
-
-		removeDestinationEventListeners();
-
-		unregisterMessageListeners();
 	}
 
 	@Override
@@ -76,12 +45,16 @@ public abstract class BaseDestination implements Destination {
 
 	@Override
 	public int getMessageListenerCount() {
+		List<MessageListener> messageListeners =
+			messageListenerRegistry.getMessageListeners(name);
+
 		return messageListeners.size();
 	}
 
 	@Override
 	public Set<MessageListener> getMessageListeners() {
-		return Collections.unmodifiableSet(messageListeners);
+		return Collections.unmodifiableSet(
+			new HashSet<>(messageListenerRegistry.getMessageListeners(name)));
 	}
 
 	@Override
@@ -103,28 +76,6 @@ public abstract class BaseDestination implements Destination {
 	}
 
 	@Override
-	public boolean register(
-		MessageListener messageListener, ClassLoader classLoader) {
-
-		InvokerMessageListener invokerMessageListener =
-			new InvokerMessageListener(messageListener, classLoader);
-
-		return registerMessageListener(invokerMessageListener);
-	}
-
-	@Override
-	public boolean removeDestinationEventListener(
-		DestinationEventListener destinationEventListener) {
-
-		return _destinationEventListeners.remove(destinationEventListener);
-	}
-
-	@Override
-	public void removeDestinationEventListeners() {
-		_destinationEventListeners.clear();
-	}
-
-	@Override
 	public void send(Message message) {
 		throw new UnsupportedOperationException();
 	}
@@ -143,82 +94,9 @@ public abstract class BaseDestination implements Destination {
 		this.name = name;
 	}
 
-	@Override
-	public boolean unregister(MessageListener messageListener) {
-		InvokerMessageListener invokerMessageListener =
-			new InvokerMessageListener(messageListener);
-
-		return unregisterMessageListener(invokerMessageListener);
-	}
-
-	public boolean unregister(
-		MessageListener messageListener, ClassLoader classLoader) {
-
-		InvokerMessageListener invokerMessageListener =
-			new InvokerMessageListener(messageListener, classLoader);
-
-		return unregisterMessageListener(invokerMessageListener);
-	}
-
-	@Override
-	public void unregisterMessageListeners() {
-		for (MessageListener messageListener : messageListeners) {
-			unregisterMessageListener((InvokerMessageListener)messageListener);
-		}
-	}
-
-	protected void fireMessageListenerRegisteredEvent(
-		MessageListener messageListener) {
-
-		for (DestinationEventListener destinationEventListener :
-				_destinationEventListeners) {
-
-			destinationEventListener.messageListenerRegistered(
-				getName(), messageListener);
-		}
-	}
-
-	protected void fireMessageListenerUnregisteredEvent(
-		MessageListener messageListener) {
-
-		for (DestinationEventListener listener : _destinationEventListeners) {
-			listener.messageListenerUnregistered(getName(), messageListener);
-		}
-	}
-
-	protected boolean registerMessageListener(
-		InvokerMessageListener invokerMessageListener) {
-
-		boolean registered = messageListeners.add(invokerMessageListener);
-
-		if (registered) {
-			fireMessageListenerRegisteredEvent(
-				invokerMessageListener.getMessageListener());
-		}
-
-		return registered;
-	}
-
-	protected boolean unregisterMessageListener(
-		InvokerMessageListener invokerMessageListener) {
-
-		boolean unregistered = messageListeners.remove(invokerMessageListener);
-
-		if (unregistered) {
-			fireMessageListenerUnregisteredEvent(
-				invokerMessageListener.getMessageListener());
-		}
-
-		return unregistered;
-	}
-
 	protected MessageListenerRegistry messageListenerRegistry;
-	protected Set<MessageListener> messageListeners = Collections.newSetFromMap(
-		new ConcurrentHashMap<>());
 	protected String name = StringPool.BLANK;
 
-	private final Set<DestinationEventListener> _destinationEventListeners =
-		Collections.newSetFromMap(new ConcurrentHashMap<>());
 	private String _destinationType;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/messaging/BaseDestination.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/messaging/BaseDestination.java
@@ -103,14 +103,6 @@ public abstract class BaseDestination implements Destination {
 	}
 
 	@Override
-	public boolean register(MessageListener messageListener) {
-		InvokerMessageListener invokerMessageListener =
-			new InvokerMessageListener(messageListener);
-
-		return registerMessageListener(invokerMessageListener);
-	}
-
-	@Override
 	public boolean register(
 		MessageListener messageListener, ClassLoader classLoader) {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/messaging/Destination.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/messaging/Destination.java
@@ -16,16 +16,9 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface Destination {
 
-	public boolean addDestinationEventListener(
-		DestinationEventListener destinationEventListener);
-
 	public void close();
 
 	public void close(boolean force);
-
-	public void copyDestinationEventListeners(Destination destination);
-
-	public void copyMessageListeners(Destination destination);
 
 	public void destroy();
 
@@ -43,18 +36,6 @@ public interface Destination {
 
 	public void open();
 
-	public boolean register(
-		MessageListener messageListener, ClassLoader classLoader);
-
-	public boolean removeDestinationEventListener(
-		DestinationEventListener destinationEventListener);
-
-	public void removeDestinationEventListeners();
-
 	public void send(Message message);
-
-	public boolean unregister(MessageListener messageListener);
-
-	public void unregisterMessageListeners();
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/messaging/Destination.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/messaging/Destination.java
@@ -43,8 +43,6 @@ public interface Destination {
 
 	public void open();
 
-	public boolean register(MessageListener messageListener);
-
 	public boolean register(
 		MessageListener messageListener, ClassLoader classLoader);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/messaging/DestinationWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/messaging/DestinationWrapper.java
@@ -17,14 +17,6 @@ public class DestinationWrapper implements Destination {
 	}
 
 	@Override
-	public boolean addDestinationEventListener(
-		DestinationEventListener destinationEventListener) {
-
-		return destination.addDestinationEventListener(
-			destinationEventListener);
-	}
-
-	@Override
 	public void close() {
 		destination.close();
 	}
@@ -32,16 +24,6 @@ public class DestinationWrapper implements Destination {
 	@Override
 	public void close(boolean force) {
 		destination.close(force);
-	}
-
-	@Override
-	public void copyDestinationEventListeners(Destination destination) {
-		this.destination.copyDestinationEventListeners(destination);
-	}
-
-	@Override
-	public void copyMessageListeners(Destination destination) {
-		this.destination.copyMessageListeners(destination);
 	}
 
 	@Override
@@ -85,38 +67,8 @@ public class DestinationWrapper implements Destination {
 	}
 
 	@Override
-	public boolean register(
-		MessageListener messageListener, ClassLoader classLoader) {
-
-		return destination.register(messageListener, classLoader);
-	}
-
-	@Override
-	public boolean removeDestinationEventListener(
-		DestinationEventListener destinationEventListener) {
-
-		return destination.removeDestinationEventListener(
-			destinationEventListener);
-	}
-
-	@Override
-	public void removeDestinationEventListeners() {
-		destination.removeDestinationEventListeners();
-	}
-
-	@Override
 	public void send(Message message) {
 		destination.send(message);
-	}
-
-	@Override
-	public boolean unregister(MessageListener messageListener) {
-		return destination.unregister(messageListener);
-	}
-
-	@Override
-	public void unregisterMessageListeners() {
-		destination.unregisterMessageListeners();
 	}
 
 	protected Destination destination;

--- a/portal-kernel/src/com/liferay/portal/kernel/messaging/DestinationWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/messaging/DestinationWrapper.java
@@ -85,11 +85,6 @@ public class DestinationWrapper implements Destination {
 	}
 
 	@Override
-	public boolean register(MessageListener messageListener) {
-		return destination.register(messageListener);
-	}
-
-	@Override
 	public boolean register(
 		MessageListener messageListener, ClassLoader classLoader) {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/messaging/MessageBus.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/messaging/MessageBus.java
@@ -18,8 +18,4 @@ public interface MessageBus {
 
 	public void sendMessage(String destinationName, Message message);
 
-	public void shutdown();
-
-	public void shutdown(boolean force);
-
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/messaging/MessageBusUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/messaging/MessageBusUtil.java
@@ -33,14 +33,6 @@ public class MessageBusUtil {
 		_messageBus.sendMessage(destinationName, message);
 	}
 
-	public static void shutdown() {
-		_messageBus.shutdown();
-	}
-
-	public static void shutdown(boolean force) {
-		_messageBus.shutdown(force);
-	}
-
 	private static volatile MessageBus _messageBus =
 		ServiceProxyFactory.newServiceTrackedInstance(
 			MessageBus.class, MessageBusUtil.class, "_messageBus", true);

--- a/portal-kernel/src/com/liferay/portal/kernel/messaging/MessageListenerRegistry.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/messaging/MessageListenerRegistry.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/portal-kernel/src/com/liferay/portal/kernel/messaging/MessageListenerRegistry.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/messaging/MessageListenerRegistry.java
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.messaging;
+
+import java.util.List;
+
+/**
+ * @author Dante Wang
+ */
+public interface MessageListenerRegistry {
+
+	public List<MessageListener> getMessageListeners(String destinationName);
+
+}

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/SynchronousDestinationTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/SynchronousDestinationTestRule.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBusUtil;
 import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.messaging.MessageListenerException;
+import com.liferay.portal.kernel.messaging.MessageListenerRegistry;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule.SyncHandler;
@@ -114,11 +115,15 @@ public class SynchronousDestinationTestRule
 			}
 
 			testSynchronousDestination.setName(destinationName);
+			testSynchronousDestination.setMessageListenerRegistry(
+				_serviceTracker.getService());
 
 			return testSynchronousDestination;
 		}
 
 		public void enableSync() {
+			_serviceTracker.open();
+
 			Filter audioProcessorFilter = _registerDestinationFilter(
 				DestinationNames.DOCUMENT_LIBRARY_AUDIO_PROCESSOR);
 			Filter asyncFilter = _registerDestinationFilter(
@@ -340,6 +345,8 @@ public class SynchronousDestinationTestRule
 					invokerMessageListener.getMessageListener(),
 					invokerMessageListener.getClassLoader());
 			}
+
+			_serviceTracker.close();
 		}
 
 		/**
@@ -400,6 +407,11 @@ public class SynchronousDestinationTestRule
 		private Map<String, Destination> _destinations;
 		private final List<InvokerMessageListener>
 			_schedulerInvokerMessageListeners = new ArrayList<>();
+		private final ServiceTracker
+			<MessageListenerRegistry, MessageListenerRegistry> _serviceTracker =
+				new ServiceTracker<>(
+					SystemBundleUtil.getBundleContext(),
+					MessageListenerRegistry.class, null);
 		private Sync _sync;
 
 	}

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/SynchronousDestinationTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/SynchronousDestinationTestRule.java
@@ -6,7 +6,6 @@
 package com.liferay.portal.kernel.test.rule;
 
 import com.liferay.petra.lang.SafeCloseable;
-import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -29,18 +28,14 @@ import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule.SyncHa
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
-import com.liferay.portal.kernel.util.MapUtil;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 
 import org.junit.runner.Description;
 
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.Filter;
-import org.osgi.framework.ServiceRegistration;
 import org.osgi.util.tracker.ServiceTracker;
 
 /**
@@ -209,72 +204,24 @@ public class SynchronousDestinationTestRule
 				}
 			}
 
-			Destination schedulerDestination = _destinations.get(
+			_schedulerDestination = _destinations.get(
 				DestinationNames.SCHEDULER_DISPATCH);
 
-			if (schedulerDestination == null) {
+			if (_schedulerDestination == null) {
 				return;
 			}
 
-			for (MessageListener messageListener :
-					schedulerDestination.getMessageListeners()) {
+			Destination dummySchedulerDestination =
+				new TestSynchronousDestination() {
 
-				InvokerMessageListener invokerMessageListener =
-					(InvokerMessageListener)messageListener;
-
-				MessageListener schedulerMessageListener =
-					invokerMessageListener.getMessageListener();
-
-				schedulerDestination.unregister(schedulerMessageListener);
-
-				_schedulerInvokerMessageListeners.add(invokerMessageListener);
-			}
-
-			int workersMaxSize = ReflectionTestUtil.getFieldValue(
-				schedulerDestination, "_workersMaxSize");
-
-			CountDownLatch startCountDownLatch = new CountDownLatch(
-				workersMaxSize);
-
-			CountDownLatch endCountDownLatch = new CountDownLatch(1);
-
-			Message countDownMessage = new Message();
-
-			MessageListener messageListener = message -> {
-				if (countDownMessage == message) {
-					startCountDownLatch.countDown();
-
-					try {
-						endCountDownLatch.await();
+					@Override
+					public void send(Message message) {
 					}
-					catch (InterruptedException interruptedException) {
-						ReflectionUtil.throwException(interruptedException);
-					}
-				}
-			};
 
-			BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+				};
 
-			ServiceRegistration<MessageListener> serviceRegistration =
-				bundleContext.registerService(
-					MessageListener.class, messageListener,
-					MapUtil.singletonDictionary(
-						"destination.name", schedulerDestination.getName()));
-
-			for (int i = 0; i < workersMaxSize; i++) {
-				schedulerDestination.send(countDownMessage);
-			}
-
-			try {
-				startCountDownLatch.await();
-			}
-			catch (InterruptedException interruptedException) {
-				ReflectionUtil.throwException(interruptedException);
-			}
-
-			serviceRegistration.unregister();
-
-			endCountDownLatch.countDown();
+			_destinations.put(
+				DestinationNames.SCHEDULER_DISPATCH, dummySchedulerDestination);
 		}
 
 		public void replaceDestination(String destinationName) {
@@ -300,10 +247,6 @@ public class SynchronousDestinationTestRule
 				Destination synchronousDestination =
 					createSynchronousDestination(destinationName);
 
-				destination.copyDestinationEventListeners(
-					synchronousDestination);
-				destination.copyMessageListeners(synchronousDestination);
-
 				_destinations.put(destinationName, synchronousDestination);
 			}
 
@@ -321,6 +264,11 @@ public class SynchronousDestinationTestRule
 				_bufferedIncrementForceSyncSafeCloseable.close();
 			}
 
+			if (_schedulerDestination != null) {
+				_destinations.put(
+					DestinationNames.SCHEDULER_DISPATCH, _schedulerDestination);
+			}
+
 			for (Destination destination : _asyncServiceDestinations) {
 				_destinations.put(destination.getName(), destination);
 			}
@@ -329,21 +277,6 @@ public class SynchronousDestinationTestRule
 
 			for (String absentDestinationName : _absentDestinationNames) {
 				_destinations.remove(absentDestinationName);
-			}
-
-			Destination destination = _destinations.get(
-				DestinationNames.SCHEDULER_DISPATCH);
-
-			if (destination == null) {
-				return;
-			}
-
-			for (InvokerMessageListener invokerMessageListener :
-					_schedulerInvokerMessageListeners) {
-
-				destination.register(
-					invokerMessageListener.getMessageListener(),
-					invokerMessageListener.getClassLoader());
 			}
 
 			_serviceTracker.close();
@@ -405,6 +338,7 @@ public class SynchronousDestinationTestRule
 			new ArrayList<>();
 		private SafeCloseable _bufferedIncrementForceSyncSafeCloseable;
 		private Map<String, Destination> _destinations;
+		private Destination _schedulerDestination;
 		private final List<InvokerMessageListener>
 			_schedulerInvokerMessageListeners = new ArrayList<>();
 		private final ServiceTracker

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/SynchronousDestinationTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/SynchronousDestinationTestRule.java
@@ -420,7 +420,9 @@ public class SynchronousDestinationTestRule
 
 		@Override
 		public void send(Message message) {
-			for (MessageListener messageListener : messageListeners) {
+			for (MessageListener messageListener :
+					messageListenerRegistry.getMessageListeners(name)) {
+
 				try {
 					messageListener.receive(message);
 				}


### PR DESCRIPTION
- LPS-192572 Squashed
- LPS-194337 Create registry to centralize tracking of all MessageListener and also support DestinationEventListener which listens to MessageListener add/remove
- LPS-194337 Make the registry available to destinations by passing via setter, as the destinations are not components themselves
- LPS-194337 Apply, use message listeners obtained from the registry to send messages
- LPS-194337 Remove all usages of APIs registering and unregistering listeners on destinations
- LPS-194337 Remove these APIs
- LPS-194337 Null safe
- LPS-194337 SF
- LPS-167246 Convert method reference to ServiceTrackerList for MessageBusEventListener
- LPS-167246 Convert method reference to ServiceTrackerMap for Destination; specifically, when using ServiceTrackerMap, a destination service can be overridden by another one with higher service ranking, but can only be removed upon service unregistering, so there's no replacement anymore.
- LPS-167246 Adjust the order, the registered ManagedServiceFactory depends on the Destination service tracker map
- LPS-167246 SF, rename
- LPS-167246 No need to explicitly force close destinations upon component deactivation, as it will be called when closing the service tracker map on each tracked destination
- LPS-167246 No need to explicitly shutdown MessageBus, as the component already takes care of the shutdown by itself.
